### PR TITLE
main.jsの読み込みにtype="module"追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   </footer>
   <!-- /.l-footer -->
   
-  <script src="asset/js/main.js"></script>
+  <script type="module" src="asset/js/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
@SugawaraKouki 
index.htmlでmain.jsを読み込む際にtype="module"が足りなかったようです。

vite Uncaught SyntaxError: Cannot use import statement outside a module 
で検索すると https://github.com/vitejs/vite/issues/7416 同じように困っている人がいたので、
こういうものを参考にできると良さそうです。